### PR TITLE
feat: support .gql as a ts module

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -4,3 +4,10 @@ declare module '*.graphql' {
     const value: DocumentNode;
     export = value;
 }
+
+declare module '*.gql' {
+    import { DocumentNode } from 'graphql';
+    
+    const value: DocumentNode;
+    export = value;
+}


### PR DESCRIPTION
I wish `graphql-import-node` can support `graphql` shortname `gql`